### PR TITLE
Patch to correct handling of DESTDIR

### DIFF
--- a/lib/Module/Install/RTx.pm
+++ b/lib/Module/Install/RTx.pm
@@ -99,7 +99,7 @@ sub RTx {
     my %index = map { $_ => 1 } @INDEX_DIRS;
     $self->no_index( directory => $_ ) foreach grep !$index{$_}, @DIRS;
 
-    my $args = join ', ', map "q($_)", map { ($_, $path{$_}) }
+    my $args = join ', ', map "q($_)", map { ($_, "\$(DESTDIR)$path{$_}") }
         grep $subdirs{$_}, keys %path;
 
     print "./$_\t=> $path{$_}\n" for sort keys %subdirs;


### PR DESCRIPTION
Hello,

The patch on my local fork corrects some behaviour when using this module in places where a direct install isn't the proper action (eg: packaging an RPM).  It makes the install targets in the postamble section honour DESTDIR.

If there is anything wrong with the patch or you'd prefer some changes for any reason, let me know.

Thanks
-Ben