### PR TITLE
Add missing NAME section to POD

### DIFF
--- a/lib/Module/Install/RTx/Remove.pm
+++ b/lib/Module/Install/RTx/Remove.pm
@@ -5,6 +5,10 @@ our @EXPORT = qw/RTxRemove/;
 
 use strict;
 
+=head1 NAME
+
+Module::Install::RTx::Remove - RT extension installer (remove files)
+
 =head1 DESCRIPTION
 
 Remove specified files. Intended to remove files


### PR DESCRIPTION
This ensures that when converting to a man page the correct title and section is used.